### PR TITLE
Add warn to Logger

### DIFF
--- a/src/utils/Logger.ts
+++ b/src/utils/Logger.ts
@@ -11,6 +11,10 @@ class Logger {
     );
   }
 
+  public static warn(text: string): void {
+    console.log(`${picoColors.yellow('➤')}  ${picoColors.bgYellow(' Warn ')} ${text}`);
+  }
+
   public static info(text: string): void {
     console.log(`${picoColors.blue('➤')}  ${picoColors.bgBlue(' Info ')} ${text}`);
   }


### PR DESCRIPTION
The warn is needed to fix the URL bug for mongoDB(when url is undefined). Will be done in the future. The warning will show that not all bot functions are being used.